### PR TITLE
Experimental extends on object streams, fixes for compressed xrefs, seek backwards further

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.0
+
+- Add experimental support for extends on object streams (#29)
+- Ensure compressed xrefs can be read without decode parameters (#33)
+- Seek further backwards when searching for %%EOF (#34)
+
 ## 0.3.0
 
 - Added `pageCount` to `PDFPages`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_pdf_reader
 description: Small pure-dart library for parsing PDF files. Supports reading all pdf structures
-version: 0.3.0
+version: 0.4.0
 repository: https://github.com/NicolaVerbeeck/dart_pdf_reader
 
 environment:


### PR DESCRIPTION
- Add experimental support for extends on object streams (#29)
- Ensure compressed xrefs can be read without decode parameters (#33)
- Seek further backwards when searching for %%EOF (#34)